### PR TITLE
Add float8_e8m0_fnu OCP MX scale format

### DIFF
--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "float8_e4m3fnuz",
     "float8_e5m2",
     "float8_e5m2fnuz",
+    "float8_e8m0fnu",
     "iinfo",
     "int2",
     "int4",
@@ -39,6 +40,7 @@ from ml_dtypes._ml_dtypes_ext import float8_e4m3fn
 from ml_dtypes._ml_dtypes_ext import float8_e4m3fnuz
 from ml_dtypes._ml_dtypes_ext import float8_e5m2
 from ml_dtypes._ml_dtypes_ext import float8_e5m2fnuz
+from ml_dtypes._ml_dtypes_ext import float8_e8m0fnu
 from ml_dtypes._ml_dtypes_ext import int2
 from ml_dtypes._ml_dtypes_ext import int4
 from ml_dtypes._ml_dtypes_ext import uint2
@@ -51,6 +53,7 @@ float8_e4m3fn: Type[np.generic]
 float8_e4m3fnuz: Type[np.generic]
 float8_e5m2: Type[np.generic]
 float8_e5m2fnuz: Type[np.generic]
+float8_e8m0fnu: Type[np.generic]
 int2: Type[np.generic]
 int4: Type[np.generic]
 uint2: Type[np.generic]

--- a/ml_dtypes/_finfo.py
+++ b/ml_dtypes/_finfo.py
@@ -22,6 +22,7 @@ from ml_dtypes._ml_dtypes_ext import float8_e4m3fn
 from ml_dtypes._ml_dtypes_ext import float8_e4m3fnuz
 from ml_dtypes._ml_dtypes_ext import float8_e5m2
 from ml_dtypes._ml_dtypes_ext import float8_e5m2fnuz
+from ml_dtypes._ml_dtypes_ext import float8_e8m0fnu
 import numpy as np
 
 _bfloat16_dtype = np.dtype(bfloat16)
@@ -30,6 +31,7 @@ _float8_e4m3fn_dtype = np.dtype(float8_e4m3fn)
 _float8_e4m3fnuz_dtype = np.dtype(float8_e4m3fnuz)
 _float8_e5m2_dtype = np.dtype(float8_e5m2)
 _float8_e5m2fnuz_dtype = np.dtype(float8_e5m2fnuz)
+_float8_e8m0fnu_dtype = np.dtype(float8_e8m0fnu)
 
 
 class _Bfloat16MachArLike:
@@ -84,6 +86,15 @@ class _Float8E5m2fnuzMachArLike:
     self.smallest_normal = float8_e5m2fnuz(smallest_normal)
     smallest_subnormal = float.fromhex("0x1p-17")
     self.smallest_subnormal = float8_e5m2fnuz(smallest_subnormal)
+
+
+class _Float8E8m0fnuMachArLike:
+
+  def __init__(self):
+    smallest_normal = float.fromhex("0x1p-127")
+    self.smallest_normal = float8_e8m0fnu(smallest_normal)
+    smallest_subnormal = float.fromhex("0x1p-127")
+    self.smallest_subnormal = float8_e8m0fnu(smallest_subnormal)
 
 
 class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
@@ -360,6 +371,51 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
     # pylint: enable=protected-access
     return obj
 
+  @staticmethod
+  def _float8_e8m0fnu_finfo():
+    def float_to_str(f):
+      return "%6.2e" % float(f)
+
+    tiny = float.fromhex("0x1p-127")
+    resolution = 0.1
+    eps = float.fromhex("0x1p+0")
+    epsneg = float.fromhex("0x1p-1")
+    max_ = float.fromhex("0x1p+127")
+
+    obj = object.__new__(np.finfo)
+    obj.dtype = _float8_e8m0fnu_dtype
+    obj.bits = 8
+    obj.eps = float8_e8m0fnu(eps)
+    obj.epsneg = float8_e8m0fnu(epsneg)
+    obj.machep = 0
+    obj.negep = -1
+    obj.max = float8_e8m0fnu(max_)
+    obj.min = float8_e8m0fnu(tiny)
+    obj.nexp = 8
+    obj.nmant = 0
+    obj.iexp = obj.nexp
+    obj.maxexp = 128
+    obj.minexp = -127
+    obj.precision = 1
+    obj.resolution = float8_e8m0fnu(resolution)
+    # pylint: disable=protected-access
+    obj._machar = _Float8E8m0fnuMachArLike()
+    if not hasattr(obj, "tiny"):
+      obj.tiny = float8_e8m0fnu(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_smallest_subnormal = float_to_str(obj.smallest_subnormal)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(resolution)
+    # pylint: enable=protected-access
+    return obj
+
   def __new__(cls, dtype):
     if (
         isinstance(dtype, str)
@@ -411,4 +467,12 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
       if _float8_e5m2fnuz_dtype not in cls._finfo_cache:
         cls._finfo_cache[_float8_e5m2fnuz_dtype] = cls._float8_e5m2fnuz_finfo()
       return cls._finfo_cache[_float8_e5m2fnuz_dtype]
+    if (
+        isinstance(dtype, str)
+        and dtype == "float8_e8m0fnu"
+        or dtype == _float8_e8m0fnu_dtype
+    ):
+      if _float8_e8m0fnu_dtype not in cls._finfo_cache:
+        cls._finfo_cache[_float8_e8m0fnu_dtype] = cls._float8_e8m0fnu_finfo()
+      return cls._finfo_cache[_float8_e8m0fnu_dtype]
     return super().__new__(cls, dtype)

--- a/ml_dtypes/_src/dtypes.cc
+++ b/ml_dtypes/_src/dtypes.cc
@@ -149,6 +149,21 @@ struct TypeDescriptor<float8_e5m2fnuz> : CustomFloatType<float8_e5m2fnuz> {
 };
 
 template <>
+struct TypeDescriptor<float8_e8m0fnu> : CustomFloatType<float8_e8m0fnu> {
+  typedef float8_e8m0fnu T;
+  static constexpr bool is_floating = true;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "float8_e8m0fnu";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_e8m0fnu";
+  static constexpr const char* kTpDoc = "float8_e8m0fnu floating-point values";
+  static constexpr char kNpyDescrKind = 'V';
+  // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
+  // character is unique.
+  static constexpr char kNpyDescrType = 'W';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
 struct TypeDescriptor<int2> : IntNTypeDescriptor<int2> {
   typedef int2 T;
   static constexpr bool is_floating = false;
@@ -284,6 +299,9 @@ bool Initialize() {
   if (!RegisterFloatDtype<float8_e5m2fnuz>(numpy.get())) {
     return false;
   }
+  if (!RegisterFloatDtype<float8_e8m0fnu>(numpy.get())) {
+    return false;
+  }
 
   if (!RegisterIntNDtype<int2>(numpy.get())) {
     return false;
@@ -319,6 +337,8 @@ bool Initialize() {
   success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e4m3fn, float>();
   success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e5m2, float>();
   success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e5m2, float>();
+  success &= RegisterTwoWayCustomCast<float8_e8m0fnu, bfloat16, float>();
+  success &= RegisterTwoWayCustomCast<bfloat16, float8_e8m0fnu, float>();
   success &= RegisterOneWayCustomCast<int2, int4, int8_t>();
   success &= RegisterOneWayCustomCast<uint2, uint4, uint8_t>();
   return success;
@@ -375,6 +395,12 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__ml_dtypes_ext() {
   if (PyObject_SetAttrString(m.get(), "float8_e5m2fnuz",
                              reinterpret_cast<PyObject*>(
                                  TypeDescriptor<float8_e5m2fnuz>::type_ptr)) <
+      0) {
+    return nullptr;
+  }
+  if (PyObject_SetAttrString(m.get(), "float8_e8m0fnu",
+                             reinterpret_cast<PyObject*>(
+                                 TypeDescriptor<float8_e8m0fnu>::type_ptr)) <
       0) {
     return nullptr;
   }

--- a/ml_dtypes/include/float8.h
+++ b/ml_dtypes/include/float8.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 // 8-bit Floating Point Interchange Format, as described by
 //   https://arxiv.org/abs/2209.05433
+//   https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-12-01-pdf-1
+//   https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 
 #include <algorithm>
 #include <cmath>
@@ -48,6 +50,7 @@ class float8_e4m3fnuz;
 class float8_e4m3b11fnuz;
 class float8_e5m2;
 class float8_e5m2fnuz;
+class float8_e8m0fnu;
 
 template <typename Derived>
 class float8_base {
@@ -390,6 +393,79 @@ class float8_e5m2fnuz : public float8_base<float8_e5m2fnuz> {
   explicit EIGEN_DEVICE_FUNC operator bool() const { return rep() != 0; }
 };
 
+class float8_e8m0fnu : public float8_base<float8_e8m0fnu> {
+  // 8-bit floating point with 8 bit exponent, no sign and zero mantissa.
+  //
+  // See: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
+  //
+  // An 8-bit floating point type with no sign bit, 8 bits exponent and 0 bits
+  // mantissa. The suffix "fnuz" is consistent with LLVM/MLIR naming and is
+  // derived from the differences to IEEE floating point conventions. `F` is
+  // for "finite" (no infinities), `N` for with special NaN encoding, `U` for
+  // unsigned.
+  //
+  // This type has the following characteristics:
+  // * bit encoding: S0E8M0 - `0bEEEEEEEE`
+  // * exponent bias: 127
+  // * infinities: Not supported
+  // * NaNs: Supported with exponent bits set to 1s - `0b11111111`
+ private:
+  using Base = float8_base<float8_e8m0fnu>;
+  friend class float8_base<float8_e8m0fnu>;
+  using Base::Base;
+
+ public:
+  template <typename T, RequiresIsDerivedFromFloat8Base<T> = 0>
+  explicit EIGEN_DEVICE_FUNC float8_e8m0fnu(T f8)
+      : float8_e8m0fnu(ConvertFrom(f8)) {}
+
+  constexpr float8_e8m0fnu operator-() const {
+    // No negative numbers supported in E8M0 => NaN
+    return float8_e8m0fnu::FromRep(0xFF);
+  }
+
+  float8_e8m0fnu operator-(const float8_e8m0fnu& other) const {
+    return Base::operator-(other);
+  }
+
+  explicit EIGEN_DEVICE_FUNC operator bool() const {
+    // No zero supported in E8M0 format.
+    return true;
+  }
+
+  // Comparison simplified to uint8_t compare.
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC bool operator<(
+      const float8_e8m0fnu& other) const {
+    if (Eigen::numext::isnan(*this) || Eigen::numext::isnan(other)) {
+      return false;
+    }
+    return rep() < other.rep();
+  }
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC bool operator<=(
+      const float8_e8m0fnu& other) const {
+    if (Eigen::numext::isnan(*this) || Eigen::numext::isnan(other)) {
+      return false;
+    }
+    return rep() <= other.rep();
+  }
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC bool operator>(
+      const float8_e8m0fnu& other) const {
+    if (Eigen::numext::isnan(*this) || Eigen::numext::isnan(other)) {
+      return false;
+    }
+    return rep() > other.rep();
+  }
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC bool operator>=(
+      const float8_e8m0fnu& other) const {
+    if (Eigen::numext::isnan(*this) || Eigen::numext::isnan(other)) {
+      return false;
+    }
+    return rep() >= other.rep();
+  }
+
+};
+
+
 constexpr double ConstexprAbs(double x) { return x < 0.0 ? -x : x; }
 
 constexpr double ConstexprCeil(double x) {
@@ -439,15 +515,19 @@ constexpr int MinExponent10FromMinExponent(int min_exponent) {
 // emax * log10(2))
 constexpr int MaxExponent10FromMaxExponentAndDigits(int max_exponent,
                                                     int digits) {
-  // We only support digits in {3,4}. This table would grow if we wanted to
+  // We only support digits in {1,2,3,4}. This table would grow if we wanted to
   // handle more values.
   constexpr double kLog10OfOnePredecessor[] = {
+      // log10(1 - 2**-1)
+      -0.3010299956639812,
+      // log10(1 - 2**-2)
+      -0.12493873660829993,
       // log10(1 - 2**-3)
       -0.057991946977686754,
       // log10(1 - 2**-4)
       -0.028028723600243537,
   };
-  return static_cast<int>(ConstexprFloor(kLog10OfOnePredecessor[digits - 3] +
+  return static_cast<int>(ConstexprFloor(kLog10OfOnePredecessor[digits - 1] +
                                          max_exponent * kLog10Of2));
 }
 
@@ -764,6 +844,64 @@ struct numeric_limits_float8_e5m2fnuz : public numeric_limits_float8_base {
   }
 };
 
+struct numeric_limits_float8_e8m0fnu : public numeric_limits_float8_base {
+ private:
+  static inline constexpr const int kExponentBias = 127;
+  static inline constexpr const int kMantissaBits = 0;
+
+ public:
+  // NOLINTBEGIN: these names must match std::numeric_limits.
+  static inline constexpr const bool is_signed = false;
+  static inline constexpr const std::float_denorm_style has_denorm =
+      std::denorm_absent;
+  static inline constexpr const int digits = kMantissaBits + 1;
+  static inline constexpr const int digits10 = Digits10FromDigits(digits);
+  static inline constexpr const int max_digits10 =
+      MaxDigits10FromDigits(digits);
+  // 2**-127 smallest valid normalized value..
+  static inline constexpr const int min_exponent = -127 + 1;
+  static inline constexpr const int min_exponent10 =
+      MinExponent10FromMinExponent(min_exponent);
+  // 128 encoding using for NaN
+  static inline constexpr const int max_exponent = 127;
+  static inline constexpr const int max_exponent10 =
+      MaxExponent10FromMaxExponentAndDigits(max_exponent, digits);
+  static inline constexpr const bool is_iec559 = false;
+  static inline constexpr const bool has_infinity = false;
+  static inline constexpr const bool has_signaling_NaN = false;
+  // NOLINTEND
+
+  static constexpr float8_e8m0fnu min() {
+    return float8_e8m0fnu::FromRep(0x00);
+  }
+  static constexpr float8_e8m0fnu lowest() {
+    return float8_e8m0fnu::FromRep(0x00);
+  }
+  static constexpr float8_e8m0fnu max() {
+    return float8_e8m0fnu::FromRep(0xfe);
+  }
+  static constexpr float8_e8m0fnu epsilon() {
+    return float8_e8m0fnu::FromRep((-kMantissaBits + kExponentBias)
+                                    << kMantissaBits);
+  }
+  static constexpr float8_e8m0fnu round_error() {
+    return float8_e8m0fnu::FromRep((-1 + kExponentBias) << kMantissaBits);
+  }
+  static constexpr float8_e8m0fnu infinity() {
+    return float8_e8m0fnu::FromRep(0xFF);
+  }  // NaN.
+  static constexpr float8_e8m0fnu quiet_NaN() {
+    return float8_e8m0fnu::FromRep(0xFF);
+  }
+  static constexpr float8_e8m0fnu signaling_NaN() {
+    return float8_e8m0fnu::FromRep(0xFF);
+  }
+  static constexpr float8_e8m0fnu denorm_min() {
+    // No denorm => smallest value.
+    return float8_e8m0fnu::FromRep(0x00);
+  }
+};
+
 }  // namespace float8_internal
 }  // namespace ml_dtypes
 
@@ -788,6 +926,10 @@ struct numeric_limits<ml_dtypes::float8_internal::float8_e5m2>
 template <>
 struct numeric_limits<ml_dtypes::float8_internal::float8_e5m2fnuz>
     : public ml_dtypes::float8_internal::numeric_limits_float8_e5m2fnuz {};
+
+template <>
+struct numeric_limits<ml_dtypes::float8_internal::float8_e8m0fnu>
+    : public ml_dtypes::float8_internal::numeric_limits_float8_e8m0fnu {};
 }  // namespace std
 
 namespace ml_dtypes {
@@ -839,6 +981,14 @@ constexpr inline bool(isnan)(const float8_e5m2fnuz& a) {
   return a.rep() == 0x80;
 }
 
+constexpr inline float8_e8m0fnu abs(const float8_e8m0fnu& a) {
+  return a;
+}
+
+constexpr inline bool(isnan)(const float8_e8m0fnu& a) {
+  return a.rep() == 0xff;
+}
+
 template <typename Float8>
 constexpr inline bool(isinf)(const float8_base<Float8>& a) {
   if constexpr (std::numeric_limits<Float8>::has_infinity) {
@@ -865,6 +1015,32 @@ std::ostream& operator<<(std::ostream& os, const float8_base<Float8>& f8) {
 // Inline conversion routines between float8 and other types.
 //==============================================================================
 
+template<typename T>
+bool constexpr IsPowerOfTwo(T x) {
+    return (x != 0) && ((x & (x - 1)) == 0);
+}
+// Helper for getting a bytes size which is a power of two.
+template <int Size>
+struct NextPowerOfTwo {
+  static constexpr int value = Size;
+};
+template <>
+struct NextPowerOfTwo<3> {
+  static constexpr int value = 4;
+};
+template <>
+struct NextPowerOfTwo<5> {
+  static constexpr int value = 8;
+};
+template <>
+struct NextPowerOfTwo<6> {
+  static constexpr int value = 8;
+};
+template <>
+struct NextPowerOfTwo<7> {
+  static constexpr int value = 8;
+};
+
 // Helper for getting a bit representation provided a byte size.
 template <int kNumBytes>
 using GetUnsignedInteger =
@@ -890,9 +1066,13 @@ struct ConvertImpl<Scalar, Scalar, /*kSaturate=*/kSaturate,
 template <typename Float>
 struct TraitsBase {
   using BitsType = GetUnsignedInteger<sizeof(Float)>;
+  static constexpr bool kIsSigned = std::numeric_limits<Float>::is_signed;
+  static constexpr bool kHasZero = true;
+
   static constexpr int kBits = sizeof(Float) * CHAR_BIT;
   static constexpr int kMantissaBits = Eigen::NumTraits<Float>::digits() - 1;
-  static constexpr int kExponentBits = kBits - kMantissaBits - 1;
+  // Extra bit used in exponent for unsigned float.
+  static constexpr int kExponentBits = kBits - kMantissaBits - int(kIsSigned);
   static constexpr BitsType kExponentMask = ((BitsType{1} << kExponentBits) - 1)
                                             << kMantissaBits;
   static constexpr BitsType kMantissaMask = (BitsType{1} << kMantissaBits) - 1;
@@ -917,6 +1097,13 @@ template <>
 struct Traits<float8_e5m2fnuz> : public TraitsBase<float8_e5m2fnuz> {
   using Base = TraitsBase<float8_e5m2fnuz>;
   static constexpr int kExponentBias = Base::kExponentBias + 1;
+};
+
+template <>
+struct Traits<float8_e8m0fnu> : public TraitsBase<float8_e8m0fnu> {
+  using Base = TraitsBase<float8_e8m0fnu>;
+  // No zero in E8MO OCP MX format description.
+  static constexpr bool kHasZero = false;
 };
 
 template <typename Bits>
@@ -1001,6 +1188,8 @@ struct ConvertImpl<From, To, kSaturate, kTruncate,
                    std::enable_if_t<!std::is_same_v<From, To>>> {
   using FromTraits = Traits<From>;
   using FromBits = typename FromTraits::BitsType;
+  static constexpr bool kFromIsSigned = FromTraits::kIsSigned;
+  static constexpr bool kFromHasZero = FromTraits::kHasZero;
   static constexpr int kFromBits = FromTraits::kBits;
   static constexpr int kFromMantissaBits = FromTraits::kMantissaBits;
   static constexpr int kFromExponentBits = FromTraits::kExponentBits;
@@ -1009,6 +1198,8 @@ struct ConvertImpl<From, To, kSaturate, kTruncate,
 
   using ToTraits = Traits<To>;
   using ToBits = typename ToTraits::BitsType;
+  static constexpr bool kToIsSigned = ToTraits::kIsSigned;
+  static constexpr bool kToHasZero = ToTraits::kHasZero;
   static constexpr int kToBits = ToTraits::kBits;
   static constexpr int kToMantissaBits = ToTraits::kMantissaBits;
   static constexpr int kToExponentBits = ToTraits::kExponentBits;
@@ -1020,15 +1211,20 @@ struct ConvertImpl<From, To, kSaturate, kTruncate,
   static constexpr int kWideBits =
       (std::max(kToMantissaBits, kFromMantissaBits)) +  // Max significand.
       (std::max(kToExponentBits, kFromExponentBits));   // Max exponent.
-  static constexpr int kWideBytes = (kWideBits + (CHAR_BIT - 1)) / CHAR_BIT;
+  static constexpr int kWideBytesRaw = (kWideBits + (CHAR_BIT - 1)) / CHAR_BIT;
+  // Need a power of two (i.e. not 3 bytes).
+  static constexpr int kWideBytes = NextPowerOfTwo<kWideBytesRaw>::value;
+
   using WideBits = GetUnsignedInteger<kWideBytes>;
+  static_assert(!std::is_void_v<WideBits>, "`WideBits` type can not be void type.");
+
   static constexpr int kExponentOffset = kToExponentBias - kFromExponentBias;
   static constexpr int kDigitShift = kToMantissaBits - kFromMantissaBits;
 
   static EIGEN_DEVICE_FUNC inline To run(From from) {
     // Shift bits to destination type, without sign bit.
     const bool from_sign_bit =
-        Eigen::numext::bit_cast<FromBits>(from) >> (kFromBits - 1);
+        Eigen::numext::bit_cast<FromBits>(from) >> (kFromBits - 1) && kFromIsSigned;
     const FromBits from_bits =
         Eigen::numext::bit_cast<FromBits>(Eigen::numext::abs(from));
 
@@ -1041,8 +1237,23 @@ struct ConvertImpl<From, To, kSaturate, kTruncate,
       return from_sign_bit ? -Eigen::NumTraits<To>::quiet_NaN()
                            : Eigen::NumTraits<To>::quiet_NaN();
     }
-    if (from_bits == 0) {
-      return from_sign_bit ? -To{} : To{};
+    // Dealing with zero, when `From` has one.
+    if (from_bits == 0 && kFromHasZero) {
+      if constexpr(kToHasZero) {
+        // Keep the sign, if `To` supports it.
+        return from_sign_bit && kToIsSigned ? -To{} : To{};
+      }
+      else {
+        return kSaturate ? std::numeric_limits<To>::denorm_min()
+                       : Eigen::NumTraits<To>::quiet_NaN();
+      }
+    }
+    // `To` unsigned floating format: NaN or saturate.
+    if constexpr(!kToIsSigned && kFromIsSigned) {
+      if (from_sign_bit) {
+        return kSaturate ? std::numeric_limits<To>::lowest()
+                       : Eigen::NumTraits<To>::quiet_NaN();
+      }
     }
 
     const int biased_from_exponent = from_bits >> kFromMantissaBits;
@@ -1096,7 +1307,8 @@ struct ConvertImpl<From, To, kSaturate, kTruncate,
       // Subnormals and zero.
       if (biased_to_exponent <= 0) {
         // Round and shift mantissa down.
-        FromBits from_has_leading_one = (biased_from_exponent > 0 ? 1 : 0);
+        // Zero exponent valid if From has no zero representation.
+        FromBits from_has_leading_one = (biased_from_exponent > 0 || !kFromHasZero ? 1 : 0);
         int exponent_shift =
             -kDigitShift - biased_to_exponent + from_has_leading_one;
         // Insert the implicit leading 1 bit on the mantissa for normalized
@@ -1283,6 +1495,7 @@ using float8_e4m3fnuz = float8_internal::float8_e4m3fnuz;
 using float8_e4m3b11fnuz = float8_internal::float8_e4m3b11fnuz;
 using float8_e5m2 = float8_internal::float8_e5m2;
 using float8_e5m2fnuz = float8_internal::float8_e5m2fnuz;
+using float8_e8m0fnu = float8_internal::float8_e8m0fnu;
 
 }  // namespace ml_dtypes
 


### PR DESCRIPTION
Adding the OCP MX scale format `E8M0`, which has the following properties:
* Unsigned format;
* 8 exponent bits;
* Exponent range from -127 to 127;
* No zero and infinity;
* Single NaN value (0xFF);

`ml_dtypes` `float8_base` class has been extended to support floating point formats
which are unsigned and with no zero (with `kIsSigned` and `kHasZero` Traits properties).

Using these traits, `float8_e8m0_fnu` has been implemented using the existing functionalities.
Float8 unit tests have been extended to be able to cover unsigned floating point formats.